### PR TITLE
Fix bug on inconsistency of count matrix with feature info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,17 +13,8 @@ RUN apt-get -qq update && \
         python3-dev \
         python3-pip
 
-RUN pip3 install setuptools==47.1.1 --no-cache-dir && \
-    pip3 install cython==0.29.19 --no-cache-dir && \
-    pip3 install numpy==1.18.5 --no-cache-dir && \
-    pip3 install scipy==1.4.1 --no-cache-dir && \
-    pip3 install pandas==1.0.4 --no-cache-dir && \
-    pip3 install anndata==0.7.3 --no-cache-dir && \
-    pip3 install loompy==3.0.6 --no-cache-dir && \
-    pip3 install docopt==0.6.2 --no-cache-dir && \
-    pip3 install natsort==7.0.1 --no-cache-dir && \
-    pip3 install importlib-metadata==1.6.0 --no-cache-dir && \
-    pip3 install zarr==2.4.0 --no-cache-dir
+RUN pip3 install setuptools --no-cache-dir && \
+    pip3 install cython --no-cache-dir
 
 RUN apt-get -qq -y remove curl gnupg && \
     apt-get -qq -y autoremove && \

--- a/pegasusio/aggr_data.py
+++ b/pegasusio/aggr_data.py
@@ -25,7 +25,7 @@ def _get_fillna_dict(df: pd.DataFrame) -> dict:
             fillna_dict[column] = ""
         else:
             raise ValueError(f"{column} has unsupported dtype {df[column].dtype}!")
-        
+
     return fillna_dict
 
 
@@ -98,7 +98,7 @@ class AggrData:
                     data = np.concatenate(data_list)
                     row = np.concatenate(row_list)
                     col = np.concatenate(col_list)
-                    matrices[mat_key] = coo_matrix((data, (row, col))).tocsr(copy = False)
+                    matrices[mat_key] = coo_matrix((data, (row, col)), shape=(row_base, feature_metadata.shape[0])).tocsr(copy = False)
 
         return matrices
 
@@ -154,7 +154,7 @@ class AggrData:
 
 
         matrices = self._merge_matrices(feature_metadata, unilist, modality)
-        
+
 
         uns_dict = {}
         metadata = {"genome": unilist[0].metadata["genome"], "modality": unilist[0].metadata["modality"]}


### PR DESCRIPTION
In aggregation, if a feature appears in at least one sample, but none of them has cell expressing this feature, then the aggregated count matrix will have `.shape[1]` less than feature metadata `.var.shape[0]` by `1`, because this matrix is constructed in COOrdinate format. Thus the aggregation fails.

To fix it, enforce the shape of the aggregated count matrix when constructing.

Also, I update `Dockerfile` for travis testing to avoid its failure during building the docker image.