### PR TITLE
Resolve genome and modality naming; Update unit tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get -qq update && \
     apt-get -qq -y install --no-install-recommends \
         build-essential \
-        gnupg \
-        curl \
         git \
         python3 \
         python3-dev \
@@ -15,12 +13,10 @@ RUN apt-get -qq update && \
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
-RUN python -m pip install --upgrade pip --no-cache-dir && \
-    python -m pip install setuptools --no-cache-dir && \
-    python -m pip install cython --no-cache-dir
+RUN python -m pip install --upgrade pip && \
+    python -m pip install setuptools wheel
 
-RUN apt-get -qq -y remove curl gnupg && \
-    apt-get -qq -y autoremove && \
+RUN apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
 

--- a/pegasusio/unimodal_data.py
+++ b/pegasusio/unimodal_data.py
@@ -46,10 +46,8 @@ class UnimodalData:
         self.feature_multiarrays = DataDict(feature_multiarrays)
 
         self.metadata = DataDict(metadata)  # other metadata, a dictionary
-        if genome is not None:
-            self.metadata['genome'] = genome
-        if modality is not None:
-            self.metadata['modality'] = modality
+        self._set_genome(genome)
+        self._set_modality(modality)
 
         if cur_matrix not in matrices.keys():
             raise ValueError("Cannot find the default count matrix to bind to. Please set 'cur_matrix' argument in UnimodalData constructor!")
@@ -427,13 +425,8 @@ class UnimodalData:
 
         self.metadata = DataDict(dict(data.uns))
 
-        if genome is not None:
-            self.metadata["genome"] = genome
-        elif "genome" not in self.metadata:
-            self.metadata["genome"] = "unknown"
-        elif isinstance(self.metadata["genome"], np.ndarray):
-            assert self.metadata["genome"].ndim == 1
-            self.metadata["genome"] = self.metadata["genome"][0]
+        self._set_genome(genome)
+        self._set_modality(modality)
 
         if modality is not None:
             self.metadata["modality"] = modality
@@ -446,6 +439,23 @@ class UnimodalData:
         self._cur_matrix = "X"
         self._shape = data.shape
 
+    def _set_genome(self, genome):
+        if genome is not None:
+            self.metadata["genome"] = genome
+        elif "genome" not in self.metadata:
+            self.metadata["genome"] = "unknown"
+        elif isinstance(self.metadata["genome"], np.ndarray):
+            assert self.metadata["genome"].ndim == 1
+            self.metadata["genome"] = self.metadata["genome"][0]
+
+    def _set_modality(self, modality):
+        if modality is not None:
+            self.metadata["modality"] = modality
+        elif "modality" not in self.metadata:
+            if self.metadata.get("experiment_type", "none") in modalities:
+                self.metadata["modality"] = self.metadata.pop("experiment_type")
+            else:
+                self.metadata["modality"] = "rna"
 
     def to_anndata(self) -> anndata.AnnData:
         """ Convert to anndata

--- a/pegasusio/unimodal_data.py
+++ b/pegasusio/unimodal_data.py
@@ -428,14 +428,6 @@ class UnimodalData:
         self._set_genome(genome)
         self._set_modality(modality)
 
-        if modality is not None:
-            self.metadata["modality"] = modality
-        elif "modality" not in self.metadata:
-            if self.metadata.get("experiment_type", "none") in modalities:
-                self.metadata["modality"] = self.metadata.pop("experiment_type")
-            else:
-                self.metadata["modality"] = "rna"
-
         self._cur_matrix = "X"
         self._shape = data.shape
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,28 +4,52 @@ import pegasusio as io
 
 class TestIO(unittest.TestCase):
 
-    def test_read_h5ad(self):
+    def test_h5ad(self):
         data = io.read_input("pegasusio-test-data/case1/pbmc3k.h5ad", genome = 'hg19')
-        self.assertEqual(data.shape, (2638, 1838))
+        io.write_output(data, "pegasusio-test-data/case1/pbmc3k_out.h5ad")
+        data = io.read_input("pegasusio-test-data/case1/pbmc3k_out.h5ad")
+
+        self.assertEqual(data.shape, (2638, 1838), "Count matrix shape differs!")
+        self.assertEqual(data.get_genome(), "hg19", "Genome differs!")
+        self.assertEqual(data.get_modality(), "rna", "Modality differs!")
 
     def test_mixture_data(self):
         data = io.read_input("pegasusio-test-data/case2/1k_hgmm_v3_filtered_feature_bc_matrix.h5")
         data.select_data('mm10-rna')
-        self.assertEqual(data.shape, (1063, 54232))
+        self.assertEqual(data.shape, (1063, 54232), "Mouse data shape differs!")
+        self.assertEqual(data.get_genome(), "mm10", "Mouse data genome differs!")
+        self.assertEqual(data.get_modality(), "rna", "Mouse data modality differs!")
         data.select_data('hg19-rna')
-        self.assertEqual(data.shape, (1063, 57905))
+        self.assertEqual(data.shape, (1063, 57905), "Human data shape differs!")
+        self.assertEqual(data.get_genome(), "hg19", "Human data genome differs!")
+        self.assertEqual(data.get_modality(), "rna", "Human data modality differs!")
 
-    def test_read_10x_mtx(self):
+    def test_10x_mtx(self):
         data = io.read_input("pegasusio-test-data/case3/42468c97-1c5a-4c9f-86ea-9eaa1239445a.mtx", genome = 'hg19')
-        self.assertEqual(data.shape, (2544, 58347))
+        io.write_output(data, "pegasusio-test-data/case3/test.mtx")
+        data = io.read_input("pegasusio-test-data/case3/test.mtx")
 
-    def test_read_loom(self):
+        self.assertEqual(data.shape, (2544, 58347), "Count matrix shape differs!")
+        self.assertEqual(data.get_genome(), "hg19", "Genome differs!")
+        self.assertEqual(data.get_modality(), "rna", "Modality differs!")
+
+    def test_loom(self):
         data = io.read_input("pegasusio-test-data/case3/pancreas.loom", genome = 'hg19')
-        self.assertEqual(data.shape, (2544, 58347))
+        io.write_output(data, "pegasusio-test-data/case3/pancreas_out.loom")
+        data = io.read_input("pegasusio-test-data/case3/pancreas_out.loom")
 
-    def test_read_zarr(self):
+        self.assertEqual(data.shape, (2544, 58347), "Count matrix shape differs!")
+        self.assertEqual(data.get_genome(), "hg19", "Genome differs!")
+        self.assertEqual(data.get_modality(), "rna", "Modality differs!")
+
+    def test_zarr(self):
         data = io.read_input("pegasusio-test-data/case4/MantonBM1_1_dbls.zarr")
-        self.assertEqual(data.shape, (4274, 19360))
+        io.write_output(data, "pegasusio-test-data/case4/MantonBM_out.zarr")
+        data = io.read_input("pegasusio-test-data/case4/MantonBM_out.zarr")
+
+        self.assertEqual(data.shape, (4274, 19360), "Count matrix shape differs!")
+        self.assertEqual(data.get_genome(), "GRCh38", "Genome differs!")
+        self.assertEqual(data.get_modality(), "rna", "Modality differs!")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* In `unimodal_data.py`: This is to resolve the bug mentioned in Issue #51 .
    * Wrap up the way of specifying `genome` and `modality` in `from_anndata()` function as auxiliary functions: `_set_genome()` and `_set_modality()`.
    * In `__init__()`: Use the two auxiliary functions above to specify `genome` and `modality`.
* Update unit test script:
    * Now test both `read_input()` and `write_output()`.
    * Test if `genome` and `modality` attributes are correctly specified.
* Update testing docker:
    * No need to install `gnupg` and `curl`, as we no longer use `google-cloud-sdk` when testing.
    * No need to PIP install `cython` separately.
    * PIP Install `wheel` to build some dependencies from binary wheels.
    * PIP install doesn't need `--no-cache-dir` option.