### PR TITLE
spatial read and write to zarr

### DIFF
--- a/pegasusio/__init__.py
+++ b/pegasusio/__init__.py
@@ -14,7 +14,7 @@ logger.addHandler(ch)
 warnings.filterwarnings("ignore", category=FutureWarning, module='anndata')
 
 
-modalities = ['rna', 'citeseq', 'hashing', 'tcr', 'bcr', 'crispr', 'atac', 'cyto', 'nanostring']
+modalities = ['rna', 'citeseq', 'hashing', 'tcr', 'bcr', 'crispr', 'atac', 'cyto', 'nanostring', 'visium']
 
 from .decorators import timer, run_gc
 
@@ -23,6 +23,7 @@ from .vdj_data import VDJData
 from .citeseq_data import CITESeqData
 from .cyto_data import CytoData
 from .nanostring_data import NanostringData
+from .spatial_data import SpatialData
 from .qc_utils import calc_qc_filters, apply_qc_filters, DictWithDefault
 from .multimodal_data import MultimodalData
 from .aggr_data import AggrData, _fillna

--- a/pegasusio/multimodal_data.py
+++ b/pegasusio/multimodal_data.py
@@ -1,7 +1,7 @@
 import gc
 import numpy as np
 import pandas as pd
-from scipy.sparse import csr_matrix, hstack, vstack
+from scipy.sparse import csr_matrix, hstack
 from typing import List, Dict, Union, Set, Tuple, Optional
 
 import logging
@@ -46,6 +46,17 @@ class MultimodalData:
                 raise ValueError(f"Detected duplicated key '{key}'")
             self.data[key] = data.data[key]
 
+    # Check if the img field is there
+    @property
+    def img(self) -> Union[pd.DataFrame, None]:
+        return self._unidata.img if self._unidata is not None and hasattr(self._unidata, 'img') else None
+
+    # Set the img field if needed
+    @img.setter
+    def img(self, img: pd.DataFrame):
+        assert self._unidata is not None 
+        assert self._unidata.get_modality() ==  "visium", "data needs to be spatial"
+        self._unidata.img = img
 
     @property
     def obs(self) -> Union[pd.DataFrame, None]:
@@ -358,7 +369,6 @@ class MultimodalData:
         """
         Filter each "rna" modality UnimodalData in the focus_list separately using the set filtration parameters. Then for all other UnimodalData objects, select only barcodes that are in the union of selected barcodes from previously filtered UnimodalData objects.
         If focus_list is None, focus_list = [self._selected]
-
         Parameters
         ----------
         select_singlets: ``bool``, optional, default ``False``

--- a/pegasusio/spatial_data.py
+++ b/pegasusio/spatial_data.py
@@ -6,10 +6,18 @@ from typing import Dict, Optional, Union
 import logging
 
 from pegasusio.unimodal_data import UnimodalData
+
 logger = logging.getLogger(__name__)
 
 
 class SpatialData(UnimodalData):
+    """
+    Class to implement data structure to
+    manipulate spatial data with the spatial image (img) field
+    This class extends UnimodalData with additional
+    functions specific to the img field
+    """
+
     def __init__(
         self,
         barcode_metadata: Optional[Union[dict, pd.DataFrame]] = None,
@@ -21,7 +29,7 @@ class SpatialData(UnimodalData):
         barcode_multigraphs: Optional[Dict[str, csr_matrix]] = None,
         feature_multigraphs: Optional[Dict[str, csr_matrix]] = None,
         cur_matrix: str = "raw.data",
-        img = None,
+        img=None,
     ) -> None:
         assert metadata["modality"] == "visium"
         super().__init__(

--- a/pegasusio/spatial_data.py
+++ b/pegasusio/spatial_data.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pandas as pd
+from scipy.sparse import csr_matrix
+from typing import Dict, Optional, Union
+
+import logging
+
+from pegasusio.unimodal_data import UnimodalData
+logger = logging.getLogger(__name__)
+
+
+class SpatialData(UnimodalData):
+    def __init__(
+        self,
+        barcode_metadata: Optional[Union[dict, pd.DataFrame]] = None,
+        feature_metadata: Optional[Union[dict, pd.DataFrame]] = None,
+        matrices: Optional[Dict[str, csr_matrix]] = None,
+        metadata: Optional[dict] = None,
+        barcode_multiarrays: Optional[Dict[str, np.ndarray]] = None,
+        feature_multiarrays: Optional[Dict[str, np.ndarray]] = None,
+        barcode_multigraphs: Optional[Dict[str, csr_matrix]] = None,
+        feature_multigraphs: Optional[Dict[str, csr_matrix]] = None,
+        cur_matrix: str = "raw.data",
+        img = None,
+    ) -> None:
+        assert metadata["modality"] == "visium"
+        super().__init__(
+            barcode_metadata,
+            feature_metadata,
+            matrices,
+            metadata,
+            barcode_multiarrays,
+            feature_multiarrays,
+            barcode_multigraphs,
+            feature_multigraphs,
+            cur_matrix,
+        )
+        self._img = img
+
+    @property
+    def img(self) -> Optional[pd.DataFrame]:
+        return self._img
+
+    @img.setter
+    def img(self, img: pd.DataFrame):
+        self._img = img
+
+    def __repr__(self) -> str:
+        repr_str = super().__repr__()
+        key = "img"
+        fstr = self._gen_repr_str_for_attrs(key)
+        if fstr != "":
+            repr_str += f"\n    {key}: {fstr}"
+        return repr_str

--- a/pegasusio/spatial_utils.py
+++ b/pegasusio/spatial_utils.py
@@ -1,0 +1,105 @@
+import os
+
+import pandas as pd
+
+from pegasusio import MultimodalData, SpatialData
+from .hdf5_utils import load_10x_h5_file
+import json
+from PIL import Image
+
+
+def process_spatial_metadata(df):
+    df["in_tissue"] = df["in_tissue"].apply(lambda n: True if n == 1 else False)
+    df["barcodekey"] = df["barcodekey"].map(lambda s: s.split("-")[0])
+    df.set_index("barcodekey", inplace=True)
+
+
+def is_image(filename):
+    return filename.endswith((".png", ".jpg"))
+
+
+def load_visium_folder(input_path) -> MultimodalData:
+    file_list = os.listdir(input_path)
+    sample_id = input_path.split("/")[-1]
+    # Load count matrix.
+    hdf5_filename = "raw_feature_bc_matrix.h5"
+    assert hdf5_filename in file_list, "Raw count hdf5 file is missing!"
+    rna_data = load_10x_h5_file(f"{input_path}/{hdf5_filename}")
+
+    # Load spatial metadata.
+    assert ("spatial" in file_list) and (
+        os.path.isdir(f"{input_path}/spatial")
+    ), "Spatial folder is missing!"
+    tissue_pos_csv = "spatial/tissue_positions_list.csv"
+    spatial_metadata = pd.read_csv(
+        f"{input_path}/{tissue_pos_csv}",
+        names=[
+            "barcodekey",
+            "in_tissue",
+            "array_row",
+            "array_col",
+            "pxl_col_in_fullres",
+            "pxl_row_in_fullres",
+        ],
+    )
+    process_spatial_metadata(spatial_metadata)
+
+    barcode_metadata = pd.concat([rna_data.obs, spatial_metadata], axis=1)
+    feature_metadata = rna_data.var
+
+    matrices = {"raw.data": rna_data.X}
+    metadata = {"genome": rna_data.get_genome(), "modality": "visium"}
+
+    #  Store “pxl_col_in_fullres” and ”pxl_row_in_fullres” as a 2D array,
+    # which is the spatial location info of each cell in the dataset.
+    obsm = spatial_metadata[["pxl_col_in_fullres", "pxl_row_in_fullres"]]
+    barcode_multiarrays = {"spatial_coordinates": obsm.to_numpy()}
+
+    #  Store all the other spatial info of cells, i.e. “in_tissue”, “array_row”, and “array_col”
+    obs = spatial_metadata[["in_tissue", "array_row", "array_col"]]
+    barcode_metadata = obs
+
+    # Store image metadata as a Pandas DataFrame, with the following structure:
+    img = pd.DataFrame()
+    spatial_path = f"{input_path}/spatial"
+
+    with open(f"{spatial_path}/scalefactors_json.json") as fp:
+        scale_factors = json.load(fp)
+
+    arr = os.listdir(spatial_path)
+    for png in arr:
+        if not is_image(png):
+            continue
+        if "hires" in png:
+            with Image.open(f"{spatial_path}/{png}") as data:
+                data.load()
+            dict = {
+                "sample_id": sample_id,
+                "image_id": "hires",
+                "data": data,
+                "scaleFactor": scale_factors["tissue_hires_scalef"],
+            }
+            img = img.append(dict, ignore_index=True)
+        elif "lowres" in png:
+            with Image.open(f"{spatial_path}/{png}") as data:
+                data.load()
+            dict = {
+                "sample_id": sample_id,
+                "image_id": "lowres",
+                "data": data,
+                "scaleFactor": scale_factors["tissue_lowres_scalef"],
+            }
+            img = img.append(dict, ignore_index=True)
+
+    assert not img.empty, "the image data frame is empty"
+    spdata = SpatialData(
+        barcode_metadata,
+        feature_metadata,
+        matrices,
+        metadata,
+        barcode_multiarrays=barcode_multiarrays,
+        img=img,
+    )
+    data = MultimodalData(spdata)
+
+    return data

--- a/pegasusio/spatial_utils.py
+++ b/pegasusio/spatial_utils.py
@@ -19,6 +19,10 @@ def is_image(filename):
 
 
 def load_visium_folder(input_path) -> MultimodalData:
+    """
+    Method to read the visium spatial data folder
+    into MultimodalData object that contains SpatialData
+    """
     file_list = os.listdir(input_path)
     sample_id = input_path.split("/")[-1]
     # Load count matrix.

--- a/pegasusio/unimodal_data.py
+++ b/pegasusio/unimodal_data.py
@@ -4,7 +4,7 @@ from scipy.sparse import csr_matrix
 from collections.abc import MutableMapping
 from copy import deepcopy
 from natsort import natsorted
-from typing import List, Dict, Union, Set, Tuple
+from typing import List, Dict, Union, Set, Tuple, Optional
 
 import logging
 logger = logging.getLogger(__name__)
@@ -37,17 +37,17 @@ def _set_modality(metadata: dict, modality: str):
 class UnimodalData:
     def __init__(
         self,
-        barcode_metadata: Union[dict, pd.DataFrame, anndata.AnnData] = None,
-        feature_metadata: Union[dict, pd.DataFrame] = None,
-        matrices: Dict[str, csr_matrix] = None,
-        metadata: dict = None,
-        barcode_multiarrays: Dict[str, np.ndarray] = None,
-        feature_multiarrays: Dict[str, np.ndarray] = None,
-        barcode_multigraphs: Dict[str, csr_matrix] = None,
-        feature_multigraphs: Dict[str, csr_matrix] = None,
+        barcode_metadata: Optional[Union[dict, pd.DataFrame, anndata.AnnData]] = None,
+        feature_metadata: Optional[Union[dict, pd.DataFrame]] = None,
+        matrices: Optional[Dict[str, csr_matrix]] = None,
+        metadata: Optional[dict] = None,
+        barcode_multiarrays: Optional[Dict[str, np.ndarray]] = None,
+        feature_multiarrays: Optional[Dict[str, np.ndarray]] = None,
+        barcode_multigraphs: Optional[Dict[str, csr_matrix]] = None,
+        feature_multigraphs: Optional[Dict[str, csr_matrix]] = None,
         cur_matrix: str = "X",
-        genome: str = None,
-        modality: str = None,
+        genome: Optional[str] = None,
+        modality: Optional[str] = None,
     ) -> None:
         """ Note that metadata, barcode_mutiarrays, feature_multiarrays, barcode_multigraphs, feature_multigraphs can be modified.
         """
@@ -106,9 +106,13 @@ class UnimodalData:
 
         for key, mat in self.matrices.items():
             if mat.shape[0] != self._shape[0]:
-                raise ValueError(f"Wrong number of barcodes : matrix '{key}' has {mat.shape[0]} barcodes, barcodes file has {self._shape[0]} barcodes.")
+                raise ValueError(
+                    f"Wrong number of barcodes : matrix '{key}' has {mat.shape[0]} barcodes, barcodes file has {self._shape[0]} barcodes."
+                )
             if mat.shape[1] != self._shape[1]:
-                raise ValueError(f"Wrong number of features : matrix '{key}' has {mat.shape[1]} features, features file has {self._shape[1]} features.")
+                raise ValueError(
+                    f"Wrong number of features : matrix '{key}' has {mat.shape[1]} features, features file has {self._shape[1]} features."
+                )
 
         if cur_matrix not in matrices.keys():
             raise ValueError("Cannot find the default count matrix to bind to. Please set 'cur_matrix' argument in UnimodalData constructor!")
@@ -178,7 +182,6 @@ class UnimodalData:
         self.barcode_multigraphs.clear_dirty()
         self.feature_multigraphs.clear_dirty()
         self.metadata.clear_dirty()
-
 
     @property
     def obs(self) -> pd.DataFrame:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ scipy
 setuptools
 importlib_metadata>=0.7; python_version < '3.8'
 zarr
+Pillow


### PR DESCRIPTION
Pegasus spatial extension: PegasusIO: enable read/write ZARR for 10x Visium data

- Add a handler to read spatial folder to a spatial data object and build a multimodal data
- Read the image file to a PIL image object, note that this is a lazy operation
- modify the read and write functions in zarr_utilities to hangle the conversion img field in the spatial data in zarr format