### PR TITLE
Fix bug in write_dataframe of zarr_utils

### DIFF
--- a/pegasusio/zarr_utils.py
+++ b/pegasusio/zarr_utils.py
@@ -313,7 +313,7 @@ class ZarrFile:
         attrs_dict['index_name'] = df.index.name if df.index.name is not None else 'index'
         self.write_series(group, '_index', df.index.values)
         for col in df.columns:
-            if isinstance(df[col].values[0], PIL.Image.Image):
+            if (len(df[col]) != 0) and (isinstance(df[col].values[0], PIL.Image.Image)):
                 colgroup = group.create_group(col, overwrite = True)
                 x = 0
                 for data in df[col].values:


### PR DESCRIPTION
Consider the case when the data frame is empty.