### PR TITLE
initialize metadata before use

### DIFF
--- a/pegasusio/unimodal_data.py
+++ b/pegasusio/unimodal_data.py
@@ -59,6 +59,8 @@ class UnimodalData:
             barcode_metadata = pd.DataFrame()
         if feature_metadata is None:
             feature_metadata = pd.DataFrame()
+        if metadata is None:
+            metadata = dict()
         if barcode_multiarrays is None:
             barcode_multiarrays = dict()
         if feature_multiarrays is None:


### PR DESCRIPTION
This is for the case when creating a `UnimodalData` object with specified `genome` or `modality` values, users don't need to explicitly set `metadata` to `dict()` to avoid error.